### PR TITLE
fix: reduce deepseek checkpoint frequency

### DIFF
--- a/deepseek/deepseek-r1-llama-8b.isc
+++ b/deepseek/deepseek-r1-llama-8b.isc
@@ -2,10 +2,10 @@ isc_project_id = "<project-id>"
 experiment_name = "deepseek-r1-llama-8b"
 gpus = 8
 compute_mode = "cycle"
-dataset_id_list = ["38b32289-7d34-4c72-9546-9d480f676840"]
+dataset_id_list = ["255087c3-046c-421c-8fe3-6e333f14892a"]
 command = '''
 source /root/.deepseek/bin/activate && 
 torchrun --nnodes=$NNODES --nproc-per-node=$N_PROC 
 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT --node_rank=$RANK 
 /root/isc-demos/deepseek/fsdp.py 
---dataset-id 38b32289-7d34-4c72-9546-9d480f676840'''
+--dataset-id 255087c3-046c-421c-8fe3-6e333f14892a'''

--- a/deepseek/deepseek-r1-qwen-1.5b.isc
+++ b/deepseek/deepseek-r1-qwen-1.5b.isc
@@ -2,10 +2,10 @@ isc_project_id = "<project-id>"
 experiment_name = "deepseek-r1-qwen-1.5b"
 gpus = 8
 compute_mode = "cycle"
-dataset_id_list = ["6c796efa-7063-4a74-99b8-aab1c728ad98"]
+dataset_id_list = ["af72b3ae-4cd7-407a-be5e-c831a6f578a1"]
 command = '''
 source /root/.deepseek/bin/activate && 
 torchrun --nnodes=$NNODES --nproc-per-node=$N_PROC 
 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT --node_rank=$RANK 
 /root/isc-demos/deepseek/fsdp.py 
---dataset-id 6c796efa-7063-4a74-99b8-aab1c728ad98'''
+--dataset-id af72b3ae-4cd7-407a-be5e-c831a6f578a1'''

--- a/deepseek/deepseek-r1-qwen-7b.isc
+++ b/deepseek/deepseek-r1-qwen-7b.isc
@@ -2,10 +2,10 @@ isc_project_id = "<project-id>"
 experiment_name = "deepseek-r1-qwen-7b"
 gpus = 16
 compute_mode = "cycle"
-dataset_id_list = ["a792646c-39f5-4971-a169-425324fec87b"]
+dataset_id_list = ["6e226f91-6b7d-46ff-9f1e-4740efaf9b0e"]
 command = '''
 source /root/.deepseek/bin/activate && 
 torchrun --nnodes=$NNODES --nproc-per-node=$N_PROC 
 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT --node_rank=$RANK 
 /root/isc-demos/deepseek/fsdp.py 
---dataset-id a792646c-39f5-4971-a169-425324fec87b'''
+--dataset-id 6e226f91-6b7d-46ff-9f1e-4740efaf9b0e'''

--- a/deepseek/fsdp.py
+++ b/deepseek/fsdp.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
     # training
     num_epochs = 10
-    save_every_steps = 5
+    save_every_steps = 30
     model.train()
 
     for epoch in range(dataloader.sampler.epoch, num_epochs):
@@ -221,9 +221,6 @@ if __name__ == "__main__":
 
             if is_save_step:
                 force_save = False
-                if sync_loss.item() < best_loss:
-                    best_loss = sync_loss.item()
-                    force_save = True
 
                 checkpoint_directory = saver.prepare_checkpoint_directory(force_save=force_save)
                 checkpoint_writer = dcp.FileSystemWriter(checkpoint_directory)


### PR DESCRIPTION
## Description 
Disables force saves for `fdsp`, and increases steps per checkpoint frequency to reduce data usage.

## Model details
Edits fsdp deepseek model.

## Steps to reproduce any training
Uses default settings.

## Training results
n/a

## Things done
General:
- [ ] Linting (ruff, black, isort)

If adding a demo model training script:
- [ ] Atomic saving - saving is done atomically to avoid corruption
- [ ] Checkpointing - model can successfully save a checkpoint and resume.
- [ ] Completed a full run

