### PR TITLE
chore: Fashion MNIST

### DIFF
--- a/fashion_mnist/README.md
+++ b/fashion_mnist/README.md
@@ -28,3 +28,15 @@ Finally, launch an experiment with the following command.
 ```bash
 isc train fashion_mnist.isc
 ```
+
+## Run in the User Container
+
+```
+DIR=/root \
+EXPERIMENT_ID=$(python -c 'import uuid; print(uuid.uuid4())') \
+LOSSY_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/lossy \
+CHECKPOINT_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/checkpoints \
+bash -c '\
+printenv EXPERIMENT_ID && \
+torchrun --nnodes=1 --nproc-per-node=1 train.py --dataset-id 8d2de5b2-d07f-47ce-a6d6-d217a1cfa369 --lr 0.001 --batch-size 16'
+```


### PR DESCRIPTION
## Description 
1. Add how to run Fashion MNIST in `README.md` in the workstation node, before sending it to ISC.
2. Add typings to `DataLoader`. So, `train_dataloader.sampler.progress` have typing. This helps newcomer to understand. Umm, like me :)

## Model details
Fashion MNIST

## Steps to reproduce any training
```
DIR=/root \
EXPERIMENT_ID=$(python -c 'import uuid; print(uuid.uuid4())') \
LOSSY_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/lossy \
CHECKPOINT_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/checkpoints \
bash -c '\
printenv EXPERIMENT_ID && \
torchrun --nnodes=1 --nproc-per-node=1 train.py --dataset-id 8d2de5b2-d07f-47ce-a6d6-d217a1cfa369 --lr 0.001 --batch-size 16'
```

## Training results
A gist of logs, a link to tensorboard etc if relevant.

## Things done
General:
- [ ] Linting (ruff, black, isort)

   `$ black --check .` would reformat 1046 files.
   `$ ruff check .` will throw error outside the changed files.
   `$ isort **/*.py -c -v` says looks good.

If adding a demo model training script:
- [x] Atomic saving - saving is done atomically to avoid corruption

Code related to Atomic saving is not changed.
- [x] Checkpointing - model can successfully save a checkpoint and resume.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f336be27-d9c2-41d0-b51e-bcaf465e0070" />
- [ ] Completed a full run

The `AtomicDirectory` with `keep_last=-1` parameter doesn't remove the checkpoints. So, can't complete a full run. At epoch 48, the `df -h | grep /root` is at 81%.

Note: 
1. When a `DataLoader` class is initialized with the `num_workers` parameter in the workstation node, it will throw error but the training does not stop. See [num_workers error](https://discuss.pytorch.org/t/num-workers-in-dataloader-always-gives-this-error/64718/2) for more info