### PR TITLE
chore: DeepSeek

### DIFF
--- a/deepseek/README.md
+++ b/deepseek/README.md
@@ -33,6 +33,19 @@ dataset_id_list = ["<dataset-id>"]
 command = '''...'''
 ```
 ### Step 5: Launch your experiment to train
+
+Run first in the user container to cache the preprocessed dataset. Then, stop the training.
+
+```bash
+DIR=/root \
+EXPERIMENT_ID=$(python -c 'import uuid; print(uuid.uuid4())') \
+LOSSY_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/lossy \
+CHECKPOINT_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/checkpoints \
+bash -c '\
+printenv EXPERIMENT_ID && \
+torchrun --nnodes=1 --nproc-per-node=1 fsdp.py --dataset-id af72b3ae-4cd7-407a-be5e-c831a6f578a1'
+```
+
 ```bash
 isc train deepseek-r1-<model>.isc
 isc experiments


### PR DESCRIPTION
## Description 
1. Add how to run in the workstation node before sending it to ISC. Running in the workstation node will save the processed the dataset. So, each node can immediately train the model.
2. Rename `step` to `batch` because if we use gradient accumulation, maybe 1 step every few batches.
3. Add typings to `DataLoader`. So, `train_dataloader.sampler.progress` have typing. This helps newcomer to understand. Umm, like me :)

## Model details
DeepSeek

## Steps to reproduce any training
```bash
DIR=/root \
EXPERIMENT_ID=$(python -c 'import uuid; print(uuid.uuid4())') \
LOSSY_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/lossy \
CHECKPOINT_ARTIFACT_PATH=$DIR/artifacts/$EXPERIMENT_ID/checkpoints \
bash -c '\
printenv EXPERIMENT_ID && \
torchrun --nnodes=1 --nproc-per-node=1 fsdp.py --dataset-id af72b3ae-4cd7-407a-be5e-c831a6f578a1'
```

## Training results
![image](https://github.com/user-attachments/assets/1217d757-3362-41b8-9544-5c41885b7678)


## Things done
General:
- [ ] Linting (ruff, black, isort)
   
   `$ black --check .` would reformat 19 files.
   `$ ruff check .` will throw error outside the changed files.
   `$ isort **/*.py -c -v` says looks good.

If adding a demo model training script:
- [x] Atomic saving - saving is done atomically to avoid corruption
- [x] Checkpointing - model can successfully save a checkpoint and resume.
- [x] Completed a full run

